### PR TITLE
Update exampledata to 7.0.0 for Vaadin 25.1 compatibility

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -24,7 +24,7 @@
 		<dependency>
 			<groupId>com.vaadin</groupId>
 			<artifactId>exampledata</artifactId>
-			<version>6.2.0</version>
+			<version>7.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## Summary

- Update exampledata from 6.2.0 to 7.0.0 in backend/pom.xml
- exampledata 6.x references `FrontendUtils` from its old location (`com.vaadin.flow.server.frontend`), which was moved to `com.vaadin.flow.internal` in Flow 25.1
- Fixes `NoClassDefFoundError: com.vaadin.flow.server.frontend.FrontendUtils` at startup